### PR TITLE
Cl abap datfm

### DIFF
--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -17,7 +17,7 @@ ENDCLASS.
 CLASS cl_abap_datfm IMPLEMENTATION.
 
   METHOD conv_date_ext_to_int.
-    DATA is_it_ddmmyyyy_dot_seperated TYPE string VALUE '^(0[1-9]|[12][0-9]|3[01])[- \..](0[1-9]|1[012])[- \..](19|20)\d\d$'.
+    DATA is_it_ddmmyyyy_dot_seperated TYPE string VALUE '^(0[1-9]|[12][0-9]|3[01])[- \..](0[1-9]|1[012])[- \..]\d\d\d\d$'.
     IF im_datfmdes <> gregorian_dot_seperated.
       RAISE EXCEPTION TYPE cx_abap_datfm.
     ENDIF.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -9,27 +9,12 @@ CLASS cl_abap_datfm DEFINITION PUBLIC.
         ex_datfmused TYPE char1
       RAISING
         cx_abap_datfm.
-
-    CLASS-METHODS get_date_format_des
-      IMPORTING
-        im_datfm      TYPE char1 OPTIONAL
-        im_langu      TYPE spras DEFAULT sy-langu
-        im_plain      TYPE abap_bool DEFAULT abap_false
-        im_long       TYPE abap_bool DEFAULT abap_false
-      EXPORTING
-        ex_dateformat TYPE csequence
-      RAISING
-        cx_abap_datfm.
 ENDCLASS.
 
 CLASS cl_abap_datfm IMPLEMENTATION.
 
   METHOD conv_date_ext_to_int.
-    ASSERT 1 = 'todo'.
-  ENDMETHOD.
-
-  METHOD get_date_format_des.
-    ASSERT 1 = 'todo'.
+    sy-subrc = sy-subrc.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -25,6 +25,7 @@ CLASS cl_abap_datfm IMPLEMENTATION.
     ENDIF.
 
     ex_datint = im_datext+6(8) && im_datext+3(2) && im_datext(2).
+    ex_datfmused = 1.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -23,6 +23,8 @@ CLASS cl_abap_datfm IMPLEMENTATION.
     IF sy-subrc <> 0.
       RAISE EXCEPTION TYPE cx_abap_datfm.
     ENDIF.
+
+    ex_datint = im_datext+6(8) && im_datext+3(2) && im_datext(2).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -9,13 +9,16 @@ CLASS cl_abap_datfm DEFINITION PUBLIC.
         ex_datfmused TYPE char1
       RAISING
         cx_abap_datfm.
+
+  PRIVATE SECTION.
+    CONSTANTS gregorian_dot_seperated TYPE c VALUE '1'.
 ENDCLASS.
 
 CLASS cl_abap_datfm IMPLEMENTATION.
 
   METHOD conv_date_ext_to_int.
     DATA is_it_ddmmyyyy_dot_seperated TYPE string VALUE '^(0[1-9]|[12][0-9]|3[01])[- \..](0[1-9]|1[012])[- \..](19|20)\d\d$'.
-    IF im_datfmdes <> 1.
+    IF im_datfmdes <> gregorian_dot_seperated.
       RAISE EXCEPTION TYPE cx_abap_datfm.
     ENDIF.
 
@@ -25,7 +28,7 @@ CLASS cl_abap_datfm IMPLEMENTATION.
     ENDIF.
 
     ex_datint = im_datext+6(8) && im_datext+3(2) && im_datext(2).
-    ex_datfmused = 1.
+    ex_datfmused = gregorian_dot_seperated.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -14,6 +14,7 @@ ENDCLASS.
 CLASS cl_abap_datfm IMPLEMENTATION.
 
   METHOD conv_date_ext_to_int.
+    DATA is_it_ddmmyyyy_dot_seperated TYPE string VALUE '^(0[1-9]|[12][0-9]|3[01])[- \..](0[1-9]|1[012])[- \..](19|20)\d\d$'.
     IF im_datfmdes <> 1.
       RAISE EXCEPTION TYPE cx_abap_datfm.
     ENDIF.
@@ -24,6 +25,11 @@ CLASS cl_abap_datfm IMPLEMENTATION.
 
     CONDENSE im_datext.
     IF strlen( im_datext ) > 10.
+      RAISE EXCEPTION TYPE cx_abap_datfm.
+    ENDIF.
+
+    FIND ALL OCCURRENCES OF REGEX is_it_ddmmyyyy_dot_seperated IN im_datext.
+    IF sy-subrc <> 0.
       RAISE EXCEPTION TYPE cx_abap_datfm.
     ENDIF.
   ENDMETHOD.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -21,6 +21,11 @@ CLASS cl_abap_datfm IMPLEMENTATION.
     IF im_datext IS INITIAL.
       RAISE EXCEPTION TYPE cx_abap_datfm.
     ENDIF.
+
+    CONDENSE im_datext.
+    IF strlen( im_datext ) > 10.
+      RAISE EXCEPTION TYPE cx_abap_datfm.
+    ENDIF.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -11,7 +11,7 @@ CLASS cl_abap_datfm DEFINITION PUBLIC.
         cx_abap_datfm.
 
     CLASS-METHODS get_date_format_des
-        IMPORTING
+      IMPORTING
         im_datfm      TYPE char1 OPTIONAL
         im_langu      TYPE spras DEFAULT sy-langu
         im_plain      TYPE abap_bool DEFAULT abap_false

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -14,7 +14,9 @@ ENDCLASS.
 CLASS cl_abap_datfm IMPLEMENTATION.
 
   METHOD conv_date_ext_to_int.
-    sy-subrc = sy-subrc.
+    IF im_datfmdes <> 1.
+      RAISE EXCEPTION TYPE cx_abap_datfm.
+    ENDIF.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -19,15 +19,6 @@ CLASS cl_abap_datfm IMPLEMENTATION.
       RAISE EXCEPTION TYPE cx_abap_datfm.
     ENDIF.
 
-    IF im_datext IS INITIAL.
-      RAISE EXCEPTION TYPE cx_abap_datfm.
-    ENDIF.
-
-    CONDENSE im_datext.
-    IF strlen( im_datext ) > 10.
-      RAISE EXCEPTION TYPE cx_abap_datfm.
-    ENDIF.
-
     FIND ALL OCCURRENCES OF REGEX is_it_ddmmyyyy_dot_seperated IN im_datext.
     IF sy-subrc <> 0.
       RAISE EXCEPTION TYPE cx_abap_datfm.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -17,7 +17,7 @@ ENDCLASS.
 CLASS cl_abap_datfm IMPLEMENTATION.
 
   METHOD conv_date_ext_to_int.
-    DATA is_it_ddmmyyyy_dot_seperated TYPE string VALUE '^(0[1-9]|[12][0-9]|3[01])[- \..](0[1-9]|1[012])[- \..]\d\d\d\d$'.
+    DATA is_it_ddmmyyyy_dot_seperated TYPE string VALUE '^(0[0-9]|[12][0-9]|3[01])[- \..](0[0-9]|1[012])[- \..]\d\d\d\d$'.
     IF im_datfmdes <> gregorian_dot_seperated.
       RAISE EXCEPTION TYPE cx_abap_datfm.
     ENDIF.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -10,6 +10,17 @@ CLASS cl_abap_datfm DEFINITION PUBLIC.
       RAISING
         cx_abap_datfm.
 
+    CLASS-METHODS get_date_format_des
+        IMPORTING
+        im_datfm      TYPE char1 OPTIONAL
+        im_langu      TYPE spras DEFAULT sy-langu
+        im_plain      TYPE abap_bool DEFAULT abap_false
+        im_long       TYPE abap_bool DEFAULT abap_false
+      EXPORTING
+        ex_dateformat TYPE csequence
+      RAISING
+        cx_abap_datfm.
+
   PRIVATE SECTION.
     CONSTANTS gregorian_dot_seperated TYPE c VALUE '1'.
 ENDCLASS.
@@ -29,6 +40,10 @@ CLASS cl_abap_datfm IMPLEMENTATION.
 
     ex_datint = im_datext+6(8) && im_datext+3(2) && im_datext(2).
     ex_datfmused = gregorian_dot_seperated.
+  ENDMETHOD.
+
+  METHOD get_date_format_des.
+    ASSERT 1 = 'todo'.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/date_time/cl_abap_datfm.clas.abap
+++ b/src/date_time/cl_abap_datfm.clas.abap
@@ -17,6 +17,10 @@ CLASS cl_abap_datfm IMPLEMENTATION.
     IF im_datfmdes <> 1.
       RAISE EXCEPTION TYPE cx_abap_datfm.
     ENDIF.
+
+    IF im_datext IS INITIAL.
+      RAISE EXCEPTION TYPE cx_abap_datfm.
+    ENDIF.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -1,14 +1,14 @@
 CLASS ltcl_test_datfm DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
 
   PRIVATE SECTION.
-    METHODS convert_external_to_internal FOR TESTING RAISING cx_static_check.
+    METHODS acc_convert_external_to_internal FOR TESTING RAISING cx_static_check.
     METHODS fails_not_gregorian_dot_sep FOR TESTING RAISING cx_static_check.
     METHODS fails_initial_date_provided FOR TESTING RAISING cx_static_check.
     METHODS fails_date_too_long FOR TESTING RAISING cx_static_check.
     METHODS fails_gregorian_but_no_dots FOR TESTING RAISING cx_static_check.
 
     CONSTANTS christmas_external TYPE string VALUE '24.12.2023'.
-    CONSTANTS christmas TYPE d VALUE '99991231'.
+    CONSTANTS christmas TYPE d VALUE '20231224'.
     CONSTANTS gregorian_dot_seperated TYPE c VALUE '1'.
     CONSTANTS gregorian_slash_seperated TYPE c VALUE '2'.
 
@@ -16,13 +16,13 @@ ENDCLASS.
 
 CLASS ltcl_test_datfm IMPLEMENTATION.
 
-  METHOD convert_external_to_internal.
+  METHOD acc_convert_external_to_internal.
     DATA date_internal_actual TYPE d.
 
     cl_abap_datfm=>conv_date_ext_to_int( EXPORTING im_datext = christmas_external im_datfmdes = gregorian_dot_seperated
                                          IMPORTING ex_datint = date_internal_actual ).
 
-   " cl_abap_unit_assert=>assert_equals( exp = christmas act = date_internal_actual ).
+    cl_abap_unit_assert=>assert_equals( exp = christmas act = date_internal_actual ).
 
   ENDMETHOD.
 

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -12,6 +12,8 @@ CLASS ltcl_test_datfm DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT 
     CONSTANTS gregorian_dot_seperated TYPE c VALUE '1'.
     CONSTANTS gregorian_slash_seperated TYPE c VALUE '2'.
 
+    DATA exception TYPE REF TO cx_abap_datfm.
+
 ENDCLASS.
 
 CLASS ltcl_test_datfm IMPLEMENTATION.
@@ -30,7 +32,6 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
 
   METHOD fails_not_gregorian_dot_sep.
     DATA date_internal TYPE d.
-    DATA exception TYPE REF TO cx_abap_datfm.
 
     TRY.
         cl_abap_datfm=>conv_date_ext_to_int( im_datext = christmas_external im_datfmdes = gregorian_slash_seperated ).
@@ -41,7 +42,6 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
 
   METHOD fails_initial_date_provided.
     DATA initial TYPE string.
-    DATA exception TYPE REF TO cx_abap_datfm.
 
     TRY.
         cl_abap_datfm=>conv_date_ext_to_int( im_datext = initial im_datfmdes = gregorian_dot_seperated ).
@@ -52,7 +52,6 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
 
   METHOD fails_date_too_long.
     DATA this_is_too_long TYPE string VALUE '  01.01.20222  '.
-    DATA exception TYPE REF TO cx_abap_datfm.
 
     TRY.
         cl_abap_datfm=>conv_date_ext_to_int( im_datext = this_is_too_long im_datfmdes = gregorian_dot_seperated ).
@@ -63,7 +62,6 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
 
   METHOD fails_gregorian_but_no_dots.
     DATA date_seperated_by_slashes TYPE string VALUE '01/01/2022'.
-    DATA exception TYPE REF TO cx_abap_datfm.
 
     TRY.
         cl_abap_datfm=>conv_date_ext_to_int( im_datext = date_seperated_by_slashes im_datfmdes = gregorian_dot_seperated ).

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -18,12 +18,14 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
 
   METHOD acc_convert_external_to_internal.
     DATA date_internal_actual TYPE d.
+    DATA format_used_actual TYPE c.
 
     cl_abap_datfm=>conv_date_ext_to_int( EXPORTING im_datext = christmas_external im_datfmdes = gregorian_dot_seperated
-                                         IMPORTING ex_datint = date_internal_actual ).
+                                         IMPORTING ex_datint = date_internal_actual
+                                                   ex_datfmused = format_used_actual ).
 
     cl_abap_unit_assert=>assert_equals( exp = christmas act = date_internal_actual ).
-
+    cl_abap_unit_assert=>assert_equals( exp = gregorian_dot_seperated act = format_used_actual ).
   ENDMETHOD.
 
   METHOD fails_not_gregorian_dot_sep.

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -49,7 +49,7 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD fails_date_too_long.
-    DATA this_is_too_long TYPE string VALUE '  01.01.2022  '.
+    DATA this_is_too_long TYPE string VALUE '  01.01.20222  '.
     DATA exception TYPE REF TO cx_abap_datfm.
 
     TRY.

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -1,0 +1,37 @@
+CLASS ltcl_test_datfm DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
+
+  PRIVATE SECTION.
+    METHODS convert_external_to_internal FOR TESTING RAISING cx_static_check.
+    METHODS fails_not_gregorian_dot_sep FOR TESTING RAISING cx_static_check.
+
+    DATA christmas_external TYPE string VALUE '24.12.2023'.
+    DATA christmas TYPE d VALUE '99991231'.
+
+ENDCLASS.
+
+CLASS ltcl_test_datfm IMPLEMENTATION.
+
+  METHOD convert_external_to_internal.
+    DATA date_internal_actual TYPE d.
+    DATA gregorian_dot_seperated TYPE c VALUE '1'.
+
+    cl_abap_datfm=>conv_date_ext_to_int( EXPORTING im_datext = christmas_external im_datfmdes = gregorian_dot_seperated
+                                         IMPORTING ex_datint = date_internal_actual ).
+
+    cl_abap_unit_assert=>assert_equals( exp = christmas act = date_internal_actual ).
+
+  ENDMETHOD.
+
+  METHOD fails_not_gregorian_dot_sep.
+    DATA date_internal TYPE d.
+    DATA gregorian_slash_seperated TYPE c VALUE '2'.
+    DATA exception TYPE REF TO cx_abap_datfm.
+
+    TRY.
+        cl_abap_datfm=>conv_date_ext_to_int( im_datext = christmas_external im_datfmdes = gregorian_slash_seperated ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_abap_datfm INTO exception.
+    ENDTRY.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -3,6 +3,7 @@ CLASS ltcl_test_datfm DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT 
   PRIVATE SECTION.
     METHODS acc_convert_external_to_internal FOR TESTING RAISING cx_static_check.
     METHODS acc_conv_ext_to_int_infinity FOR TESTING RAISING cx_static_check.
+    METHODS acc_conv_ext_to_int_initial FOR TESTING RAISING cx_static_check.
     METHODS fails_not_gregorian_dot_sep FOR TESTING RAISING cx_static_check.
     METHODS fails_initial_date_provided FOR TESTING RAISING cx_static_check.
     METHODS fails_date_too_long FOR TESTING RAISING cx_static_check.
@@ -42,6 +43,20 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
                                                  ex_datfmused = format_used_actual ).
 
     cl_abap_unit_assert=>assert_equals( exp = infinity act = date_internal_actual ).
+    cl_abap_unit_assert=>assert_equals( exp = gregorian_dot_seperated act = format_used_actual ).
+  ENDMETHOD.
+
+  METHOD acc_conv_ext_to_int_initial.
+    DATA initial_external TYPE string VALUE '00.00.000'.
+    DATA initial TYPE d VALUE '00000000'.
+    DATA date_internal_actual TYPE d.
+    DATA format_used_actual TYPE c.
+
+    cl_abap_datfm=>conv_date_ext_to_int( EXPORTING im_datext = initial_external im_datfmdes = gregorian_dot_seperated
+                                         IMPORTING ex_datint = date_internal_actual
+                                                 ex_datfmused = format_used_actual ).
+
+    cl_abap_unit_assert=>assert_equals( exp = initial act = date_internal_actual ).
     cl_abap_unit_assert=>assert_equals( exp = gregorian_dot_seperated act = format_used_actual ).
   ENDMETHOD.
 

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -5,7 +5,7 @@ CLASS ltcl_test_datfm DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT 
     METHODS fails_not_gregorian_dot_sep FOR TESTING RAISING cx_static_check.
     METHODS fails_initial_date_provided FOR TESTING RAISING cx_static_check.
     METHODS fails_date_too_long FOR TESTING RAISING cx_static_check.
-
+    METHODS fails_gregorian_but_no_dots FOR TESTING RAISING cx_static_check.
 
     CONSTANTS christmas_external TYPE string VALUE '24.12.2023'.
     CONSTANTS christmas TYPE d VALUE '99991231'.
@@ -54,6 +54,17 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
 
     TRY.
         cl_abap_datfm=>conv_date_ext_to_int( im_datext = this_is_too_long im_datfmdes = gregorian_dot_seperated ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_abap_datfm INTO exception.
+    ENDTRY.
+  ENDMETHOD.
+
+  METHOD fails_gregorian_but_no_dots.
+    DATA date_seperated_by_slashes TYPE string VALUE '01/01/2022'.
+    DATA exception TYPE REF TO cx_abap_datfm.
+
+    TRY.
+        cl_abap_datfm=>conv_date_ext_to_int( im_datext = date_seperated_by_slashes im_datfmdes = gregorian_dot_seperated ).
         cl_abap_unit_assert=>fail( ).
       CATCH cx_abap_datfm INTO exception.
     ENDTRY.

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -39,22 +39,22 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
     DATA format_used_actual TYPE c.
 
     cl_abap_datfm=>conv_date_ext_to_int( EXPORTING im_datext = infinity_external im_datfmdes = gregorian_dot_seperated
-                                       IMPORTING ex_datint = date_internal_actual
-                                                 ex_datfmused = format_used_actual ).
+                                        IMPORTING ex_datint = date_internal_actual
+                                                  ex_datfmused = format_used_actual ).
 
     cl_abap_unit_assert=>assert_equals( exp = infinity act = date_internal_actual ).
     cl_abap_unit_assert=>assert_equals( exp = gregorian_dot_seperated act = format_used_actual ).
   ENDMETHOD.
 
   METHOD acc_conv_ext_to_int_initial.
-    DATA initial_external TYPE string VALUE '00.00.000'.
+    DATA initial_external TYPE string VALUE '00.00.0000'.
     DATA initial TYPE d VALUE '00000000'.
     DATA date_internal_actual TYPE d.
     DATA format_used_actual TYPE c.
 
     cl_abap_datfm=>conv_date_ext_to_int( EXPORTING im_datext = initial_external im_datfmdes = gregorian_dot_seperated
                                          IMPORTING ex_datint = date_internal_actual
-                                                 ex_datfmused = format_used_actual ).
+                                                   ex_datfmused = format_used_actual ).
 
     cl_abap_unit_assert=>assert_equals( exp = initial act = date_internal_actual ).
     cl_abap_unit_assert=>assert_equals( exp = gregorian_dot_seperated act = format_used_actual ).

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -2,6 +2,7 @@ CLASS ltcl_test_datfm DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT 
 
   PRIVATE SECTION.
     METHODS acc_convert_external_to_internal FOR TESTING RAISING cx_static_check.
+    METHODS acc_conv_ext_to_int_infinity FOR TESTING RAISING cx_static_check.
     METHODS fails_not_gregorian_dot_sep FOR TESTING RAISING cx_static_check.
     METHODS fails_initial_date_provided FOR TESTING RAISING cx_static_check.
     METHODS fails_date_too_long FOR TESTING RAISING cx_static_check.
@@ -29,6 +30,21 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = christmas act = date_internal_actual ).
     cl_abap_unit_assert=>assert_equals( exp = gregorian_dot_seperated act = format_used_actual ).
   ENDMETHOD.
+
+  METHOD acc_conv_ext_to_int_infinity.
+    DATA infinity_external TYPE string VALUE '31.12.9999'.
+    DATA infinity TYPE d VALUE '99991231'.
+    DATA date_internal_actual TYPE d.
+    DATA format_used_actual TYPE c.
+
+    cl_abap_datfm=>conv_date_ext_to_int( EXPORTING im_datext = infinity_external im_datfmdes = gregorian_dot_seperated
+                                       IMPORTING ex_datint = date_internal_actual
+                                                 ex_datfmused = format_used_actual ).
+
+    cl_abap_unit_assert=>assert_equals( exp = infinity act = date_internal_actual ).
+    cl_abap_unit_assert=>assert_equals( exp = gregorian_dot_seperated act = format_used_actual ).
+  ENDMETHOD.
+
 
   METHOD fails_not_gregorian_dot_sep.
     DATA date_internal TYPE d.

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -3,9 +3,13 @@ CLASS ltcl_test_datfm DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT 
   PRIVATE SECTION.
     METHODS convert_external_to_internal FOR TESTING RAISING cx_static_check.
     METHODS fails_not_gregorian_dot_sep FOR TESTING RAISING cx_static_check.
+    METHODS fails_initial_date_provided FOR TESTING RAISING cx_static_check.
 
-    DATA christmas_external TYPE string VALUE '24.12.2023'.
-    DATA christmas TYPE d VALUE '99991231'.
+
+    CONSTANTS christmas_external TYPE string VALUE '24.12.2023'.
+    CONSTANTS christmas TYPE d VALUE '99991231'.
+    CONSTANTS gregorian_dot_seperated TYPE c VALUE '1'.
+    CONSTANTS gregorian_slash_seperated TYPE c VALUE '2'.
 
 ENDCLASS.
 
@@ -13,22 +17,31 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
 
   METHOD convert_external_to_internal.
     DATA date_internal_actual TYPE d.
-    DATA gregorian_dot_seperated TYPE c VALUE '1'.
 
     cl_abap_datfm=>conv_date_ext_to_int( EXPORTING im_datext = christmas_external im_datfmdes = gregorian_dot_seperated
                                          IMPORTING ex_datint = date_internal_actual ).
 
-    cl_abap_unit_assert=>assert_equals( exp = christmas act = date_internal_actual ).
+   " cl_abap_unit_assert=>assert_equals( exp = christmas act = date_internal_actual ).
 
   ENDMETHOD.
 
   METHOD fails_not_gregorian_dot_sep.
     DATA date_internal TYPE d.
-    DATA gregorian_slash_seperated TYPE c VALUE '2'.
     DATA exception TYPE REF TO cx_abap_datfm.
 
     TRY.
         cl_abap_datfm=>conv_date_ext_to_int( im_datext = christmas_external im_datfmdes = gregorian_slash_seperated ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_abap_datfm INTO exception.
+    ENDTRY.
+  ENDMETHOD.
+
+  METHOD fails_initial_date_provided.
+    DATA initial TYPE string.
+    DATA exception TYPE REF TO cx_abap_datfm.
+
+    TRY.
+        cl_abap_datfm=>conv_date_ext_to_int( im_datext = initial im_datfmdes = gregorian_dot_seperated ).
         cl_abap_unit_assert=>fail( ).
       CATCH cx_abap_datfm INTO exception.
     ENDTRY.

--- a/src/date_time/cl_abap_datfm.clas.testclasses.abap
+++ b/src/date_time/cl_abap_datfm.clas.testclasses.abap
@@ -4,6 +4,7 @@ CLASS ltcl_test_datfm DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT 
     METHODS convert_external_to_internal FOR TESTING RAISING cx_static_check.
     METHODS fails_not_gregorian_dot_sep FOR TESTING RAISING cx_static_check.
     METHODS fails_initial_date_provided FOR TESTING RAISING cx_static_check.
+    METHODS fails_date_too_long FOR TESTING RAISING cx_static_check.
 
 
     CONSTANTS christmas_external TYPE string VALUE '24.12.2023'.
@@ -42,6 +43,17 @@ CLASS ltcl_test_datfm IMPLEMENTATION.
 
     TRY.
         cl_abap_datfm=>conv_date_ext_to_int( im_datext = initial im_datfmdes = gregorian_dot_seperated ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_abap_datfm INTO exception.
+    ENDTRY.
+  ENDMETHOD.
+
+  METHOD fails_date_too_long.
+    DATA this_is_too_long TYPE string VALUE '  01.01.2022  '.
+    DATA exception TYPE REF TO cx_abap_datfm.
+
+    TRY.
+        cl_abap_datfm=>conv_date_ext_to_int( im_datext = this_is_too_long im_datfmdes = gregorian_dot_seperated ).
         cl_abap_unit_assert=>fail( ).
       CATCH cx_abap_datfm INTO exception.
     ENDTRY.


### PR DESCRIPTION
Hi,

I wrote a quite naive implementation of the method `CONV_DATE_EXT_TO_INT`, because _really_ correct date validation is painful.  It's the only method of this class that I personally need. The conversion is only possible for dates in format DD.MM.YYYY and is guarded by a regex. 

Greetings,
Dominik