### PR TITLE
added TIMN datatype

### DIFF
--- a/src/ddic/dtel/timn.dtel.xml
+++ b/src/ddic/dtel/timn.dtel.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>TIMN</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <DOMNAME>TIME</DOMNAME>
+    <DATATYPE>TIMN</DATATYPE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>10</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>TIMN</DDTEXT>
+    <REPTEXT>TIMN</REPTEXT>
+    <SCRTEXT_S>TIMN</SCRTEXT_S>
+    <SCRTEXT_M>TIMN</SCRTEXT_M>
+    <SCRTEXT_L>TIMN</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <LENG>000006</LENG>
+    <DECIMALS>000000</DECIMALS>
+    <REFKIND>T</REFKIND>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Hi Lars, I've enabled ABAP CLoud programming Model on SCP and theres no TIMS-Dataelement available (not compatible) I added the TIMN Datelement, but I actually don't know how to test this ? Can you please have a look. Thanks