### PR TITLE
add xslt serialization error

### DIFF
--- a/src/exceptions/cx_xslt_serialization_error.clas.abap
+++ b/src/exceptions/cx_xslt_serialization_error.clas.abap
@@ -1,0 +1,7 @@
+CLASS cx_xslt_serialization_error DEFINITION PUBLIC INHERITING FROM cx_xslt_system_error.
+
+ENDCLASS.
+
+CLASS cx_xslt_serialization_error IMPLEMENTATION.
+
+ENDCLASS.


### PR DESCRIPTION
have no idea how this open-abap exactly works but it is great and maybe this PR solves my error 🤷‍♂️

added the exception cx_xslt_serialization_error

https://github.com/abap2UI5/abap2UI5/actions/runs/5410281599/jobs/9831514765?pr=323
<img width="1171" alt="image" src="https://github.com/open-abap/open-abap-core/assets/102328295/a567dd26-2ac8-4cdf-b742-ab340c322a34">
 