### PR TITLE
Generalize `get_max_value` method for packed numbers

### DIFF
--- a/src/abap/cl_abap_exceptional_values.clas.abap
+++ b/src/abap/cl_abap_exceptional_values.clas.abap
@@ -16,10 +16,13 @@ ENDCLASS.
 CLASS cl_abap_exceptional_values IMPLEMENTATION.
 
   METHOD get_max_value.
-    DATA lv_type     TYPE c LENGTH 1.
-    DATA lv_length   TYPE i.
-    DATA lv_decimals TYPE i.
-    FIELD-SYMBOLS <out> TYPE any.
+    DATA lv_type                  TYPE c LENGTH 1.
+    DATA lv_length                TYPE i.
+    DATA lv_decimals              TYPE i.
+    DATA lv_digits_before_decimal TYPE i.
+    DATA lv_integer_part          TYPE string.
+    DATA lv_decimal_part          TYPE string.
+    FIELD-SYMBOLS <out>           TYPE any.
 
     DESCRIBE FIELD in TYPE lv_type.
 
@@ -32,15 +35,20 @@ CLASS cl_abap_exceptional_values IMPLEMENTATION.
         CREATE DATA out TYPE p LENGTH lv_length DECIMALS lv_decimals.
         ASSIGN out->* TO <out>.
 
-        IF lv_length = 3 AND lv_decimals = 1.
-          <out> = '9999.9'.
-        ELSEIF lv_length = 4 AND lv_decimals = 1.
-          <out> = '999999.9'.
-        ELSEIF lv_length = 7 AND lv_decimals = 3.
-          <out> = '9999999999.999'.
-        ELSE.
-          ASSERT 1 = 'todo'.
+        lv_digits_before_decimal = lv_length * 2 - 1 - lv_decimals.
+
+        DO lv_digits_before_decimal TIMES.
+          lv_integer_part = lv_integer_part && '9'.
+        ENDDO.
+
+        IF lv_decimals > 0.
+          lv_decimal_part = '.'.
+          DO lv_decimals TIMES.
+            lv_decimal_part = lv_decimal_part && '9'.
+          ENDDO.
         ENDIF.
+
+        <out> = lv_integer_part && lv_decimal_part.
       WHEN OTHERS.
         WRITE '@KERNEL console.dir(INPUT);'.
         ASSERT 1 = 'todo'.

--- a/src/abap/cl_abap_exceptional_values.clas.testclasses.abap
+++ b/src/abap/cl_abap_exceptional_values.clas.testclasses.abap
@@ -7,6 +7,7 @@ CLASS ltcl_exceptional_values DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATIO
     METHODS max_packed1 FOR TESTING RAISING cx_static_check.
     METHODS max_packed2 FOR TESTING RAISING cx_static_check.
     METHODS max_packed3 FOR TESTING RAISING cx_static_check.
+    METHODS max_packed4 FOR TESTING RAISING cx_static_check.
     METHODS min_packed FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
@@ -47,6 +48,18 @@ CLASS ltcl_exceptional_values IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = <field>
       exp = '999999.9' ).
+  ENDMETHOD.
+
+  METHOD max_packed4.
+    DATA foo TYPE p LENGTH 9 DECIMALS 5.
+    DATA ref TYPE REF TO data.
+    FIELD-SYMBOLS <field> TYPE any.
+    ref = cl_abap_exceptional_values=>get_max_value( foo ).
+    ASSIGN ref->* TO <field>.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = <field>
+      exp = '999999999999.99999' ).
   ENDMETHOD.
 
   METHOD min_packed.


### PR DESCRIPTION
With this change, the calculation for the max value of a packed number is generalized according to the [ABAP-Documentation](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abennumber_types.htm).

As described in the documentation, a packed number with length 9 and decimals 5 consists of `9*2-1 = 17` digits in total. 5 digits are decimals and the other `17-5 = 12` are digits before the decimal point. 
