### PR TITLE
tadir author field

### DIFF
--- a/src/ddic/transparent/tadir.tabl.xml
+++ b/src/ddic/transparent/tadir.tabl.xml
@@ -121,6 +121,15 @@
      <LENG>000030</LENG>
      <MASK>  CHAR</MASK>
     </DD03P>
+    <DD03P>
+     <FIELDNAME>AUTHOR</FIELDNAME>
+     <ADMINFIELD>0</ADMINFIELD>
+     <INTTYPE>C</INTTYPE>
+     <INTLEN>000012</INTLEN>
+     <DATATYPE>CHAR</DATATYPE>
+     <LENG>000012</LENG>
+     <MASK>  CHAR</MASK>
+    </DD03P>
    </DD03P_TABLE>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
This pull request adds a new field, `AUTHOR`, to the `tadir` table definition in the file `src/ddic/transparent/tadir.tabl.xml`. The field is defined as a `CHAR` type with a length of 12 characters.