### PR TITLE
cl_abap_zip: get() raises ZIP_INDEX_ERROR for missing entries

### DIFF
--- a/src/abap/cl_abap_zip.clas.abap
+++ b/src/abap/cl_abap_zip.clas.abap
@@ -19,7 +19,9 @@ CLASS cl_abap_zip DEFINITION PUBLIC.
         name    TYPE string OPTIONAL
         index   TYPE i OPTIONAL
       EXPORTING
-        content TYPE xstring.
+        content TYPE xstring
+      EXCEPTIONS
+        zip_index_error.
 
     METHODS delete
       IMPORTING
@@ -72,6 +74,9 @@ CLASS cl_abap_zip IMPLEMENTATION.
     ASSERT index IS INITIAL.
 
     READ TABLE mt_contents WITH KEY name = name INTO ls_contents.
+    IF sy-subrc <> 0.
+      RAISE zip_index_error.
+    ENDIF.
     cl_abap_gzip=>decompress_binary(
       EXPORTING
         gzip_in     = ls_contents-compressed

--- a/src/abap/cl_abap_zip.clas.testclasses.abap
+++ b/src/abap/cl_abap_zip.clas.testclasses.abap
@@ -3,6 +3,7 @@ CLASS ltcl_test DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
   PRIVATE SECTION.
     METHODS test1 FOR TESTING RAISING cx_static_check.
     METHODS get FOR TESTING RAISING cx_static_check.
+    METHODS get_missing FOR TESTING RAISING cx_static_check.
     METHODS crc FOR TESTING RAISING cx_static_check.
     METHODS save FOR TESTING RAISING cx_static_check.
     METHODS load FOR TESTING RAISING cx_static_check.
@@ -95,6 +96,24 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = lv_act
       exp = lv_content ).
+  ENDMETHOD.
+
+  METHOD get_missing.
+    DATA lo_zip     TYPE REF TO cl_abap_zip.
+    DATA lv_content TYPE xstring.
+
+    lv_content = '1122334455667788AABBCCDDEEFF'.
+    CREATE OBJECT lo_zip.
+    lo_zip->add( name    = 'foobar'
+                 content = lv_content ).
+
+    lo_zip->get( EXPORTING  name            = 'sdfsdfsd'
+                 EXCEPTIONS zip_index_error = 1
+                            OTHERS          = 2 ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = sy-subrc
+      exp = 1 ).
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
In SAP, `get( )` raises ZIP_INDEX_ERROR when the name is not found, and callers use `get( EXCEPTIONS zip_index_error = 1 )` + sy-subrc as an existence check (bizhuka/xtt does this for image handling). Previously a missing name silently returned empty content with sy-subrc = 0.

Adds the exception to the signature and a testcase.