### PR TITLE
cl_abap_zip: implement delete()

### DIFF
--- a/src/abap/cl_abap_zip.clas.abap
+++ b/src/abap/cl_abap_zip.clas.abap
@@ -61,7 +61,19 @@ CLASS cl_abap_zip IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD delete.
-    ASSERT 1 = 'todo'.
+    DATA lv_name TYPE string.
+
+    ASSERT name IS NOT INITIAL.
+    ASSERT index IS INITIAL.
+    lv_name = name.
+
+    READ TABLE mt_contents WITH KEY name = lv_name TRANSPORTING NO FIELDS.
+    IF sy-subrc <> 0.
+      RAISE zip_index_error.
+    ENDIF.
+
+    DELETE mt_contents WHERE name = lv_name.
+    DELETE files WHERE name = lv_name.
   ENDMETHOD.
 
   METHOD get.

--- a/src/abap/cl_abap_zip.clas.testclasses.abap
+++ b/src/abap/cl_abap_zip.clas.testclasses.abap
@@ -3,6 +3,7 @@ CLASS ltcl_test DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
   PRIVATE SECTION.
     METHODS test1 FOR TESTING RAISING cx_static_check.
     METHODS get FOR TESTING RAISING cx_static_check.
+    METHODS delete FOR TESTING RAISING cx_static_check.
     METHODS crc FOR TESTING RAISING cx_static_check.
     METHODS save FOR TESTING RAISING cx_static_check.
     METHODS load FOR TESTING RAISING cx_static_check.
@@ -92,6 +93,41 @@ CLASS ltcl_test IMPLEMENTATION.
     lo_zip->get( EXPORTING name    = 'foobar'
                  IMPORTING content = lv_act ).
 
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_act
+      exp = lv_content ).
+  ENDMETHOD.
+
+  METHOD delete.
+    DATA lo_zip     TYPE REF TO cl_abap_zip.
+    DATA lv_content TYPE xstring.
+    DATA lv_act     TYPE xstring.
+
+    lv_content = '1122334455667788AABBCCDDEEFF'.
+    CREATE OBJECT lo_zip.
+    lo_zip->add( name    = 'foo'
+                 content = lv_content ).
+    lo_zip->add( name    = 'bar'
+                 content = lv_content ).
+
+    lo_zip->delete( EXPORTING  name            = 'foo'
+                    EXCEPTIONS zip_index_error = 1
+                               OTHERS          = 2 ).
+    cl_abap_unit_assert=>assert_equals(
+      act = sy-subrc
+      exp = 0 ).
+
+    " deleting again raises
+    lo_zip->delete( EXPORTING  name            = 'foo'
+                    EXCEPTIONS zip_index_error = 1
+                               OTHERS          = 2 ).
+    cl_abap_unit_assert=>assert_equals(
+      act = sy-subrc
+      exp = 1 ).
+
+    " remaining entry is untouched
+    lo_zip->get( EXPORTING name    = 'bar'
+                 IMPORTING content = lv_act ).
     cl_abap_unit_assert=>assert_equals(
       act = lv_act
       exp = lv_content ).

--- a/src/abap/cl_abap_zip.clas.testclasses.abap
+++ b/src/abap/cl_abap_zip.clas.testclasses.abap
@@ -132,6 +132,8 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = lv_act
       exp = lv_content ).
+  ENDMETHOD.
+
   METHOD get_missing.
     DATA lo_zip     TYPE REF TO cl_abap_zip.
     DATA lv_content TYPE xstring.


### PR DESCRIPTION
Implements `delete( )` by name: removes the entry from mt_contents and files, raising ZIP_INDEX_ERROR when the name is not found. Index-based access is asserted unsupported, mirroring `get( )`.

Existence is checked via READ TABLE because `DELETE ... WHERE` does not set sy-subrc in the runtime yet (fix submitted separately: abaplint/transpiler#1765).

Testcase included.