### PR TITLE
cl_abap_zip: load() supports STORED entries

### DIFF
--- a/src/abap/cl_abap_zip.clas.abap
+++ b/src/abap/cl_abap_zip.clas.abap
@@ -118,6 +118,7 @@ CLASS cl_abap_zip IMPLEMENTATION.
     DATA lv_length     TYPE i.
     DATA lv_sig        TYPE x LENGTH 4.
     DATA lv_comp_size  TYPE i.
+    DATA lv_comp_method TYPE i.
     DATA lv_name_len   TYPE i.
     DATA lv_extra_len  TYPE i.
     DATA lv_name_x     TYPE xstring.
@@ -142,6 +143,9 @@ CLASS cl_abap_zip IMPLEMENTATION.
 
       CLEAR ls_contents.
 
+* 8, 2, Compression method
+      lv_comp_method = lcl_stream=>read_int2( iv_xstr   = zip
+                                               iv_offset = lv_offset + 8 ).
 * 18, 4, Compressed size
       lv_comp_size = lcl_stream=>read_int4( iv_xstr   = zip
                                             iv_offset = lv_offset + 18 ).
@@ -168,12 +172,23 @@ CLASS cl_abap_zip IMPLEMENTATION.
       ENDIF.
       lv_offset = lv_offset + lv_comp_size.
 
-      cl_abap_gzip=>decompress_binary(
-        EXPORTING
-          gzip_in     = ls_contents-compressed
-        IMPORTING
-          raw_out     = ls_contents-content
-          raw_out_len = lv_out_len ).
+      IF lv_comp_method = 0.
+* STORED entry (no compression): the block is the content itself.
+* Recompress it so GET, which always inflates COMPRESSED, works unchanged.
+        ls_contents-content = ls_contents-compressed.
+        cl_abap_gzip=>compress_binary(
+          EXPORTING
+            raw_in   = ls_contents-content
+          IMPORTING
+            gzip_out = ls_contents-compressed ).
+      ELSE.
+        cl_abap_gzip=>decompress_binary(
+          EXPORTING
+            gzip_in     = ls_contents-compressed
+          IMPORTING
+            raw_out     = ls_contents-content
+            raw_out_len = lv_out_len ).
+      ENDIF.
 
       INSERT ls_contents INTO TABLE mt_contents.
 

--- a/src/abap/cl_abap_zip.clas.abap
+++ b/src/abap/cl_abap_zip.clas.abap
@@ -144,7 +144,7 @@ CLASS cl_abap_zip IMPLEMENTATION.
       CLEAR ls_contents.
 
 * 8, 2, Compression method
-      lv_comp_method = lcl_stream=>read_int2( iv_xstr   = zip
+      lv_comp_method = lcl_stream=>read_int2( iv_xstr    = zip
                                                iv_offset = lv_offset + 8 ).
 * 18, 4, Compressed size
       lv_comp_size = lcl_stream=>read_int4( iv_xstr   = zip

--- a/src/abap/cl_abap_zip.clas.testclasses.abap
+++ b/src/abap/cl_abap_zip.clas.testclasses.abap
@@ -8,6 +8,7 @@ CLASS ltcl_test DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
     METHODS crc FOR TESTING RAISING cx_static_check.
     METHODS save FOR TESTING RAISING cx_static_check.
     METHODS load FOR TESTING RAISING cx_static_check.
+    METHODS load_stored FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -150,6 +151,42 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = sy-subrc
       exp = 1 ).
+  ENDMETHOD.
+
+  METHOD load_stored.
+    " hand-crafted zip with a single STORED (method 0) entry:
+    " file name F, payload 4142
+    DATA lv_hex TYPE string.
+    DATA lv_zip TYPE xstring.
+    DATA lv_act TYPE xstring.
+    DATA lv_exp TYPE xstring.
+    DATA lo_zip TYPE REF TO cl_abap_zip.
+
+    CONCATENATE
+      `504B0304`            " local file header signature
+      `1400` `0000` `0000`  " version, flags, method = STORED
+      `0000` `0000`         " mod time, mod date
+      `00000000`            " crc32 (not checked by load)
+      `02000000` `02000000` " compressed / uncompressed size = 2
+      `0100` `0000`         " name length = 1, extra length = 0
+      `46`                  " file name F
+      `4142`                " stored payload
+      INTO lv_hex.
+    lv_zip = lv_hex.
+
+    CREATE OBJECT lo_zip.
+    lo_zip->load( lv_zip ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lines( lo_zip->files )
+      exp = 1 ).
+
+    lo_zip->get( EXPORTING name    = `F`
+                 IMPORTING content = lv_act ).
+    lv_exp = '4142'.
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_act
+      exp = lv_exp ).
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
`load( )` ignored the compression method field and always inflated the data block, so archives containing STORED (method 0) entries crashed with a zlib error ("invalid stored block lengths"). STORED entries are common in real files: already-compressed content such as PNG images inside xlsx/docx is typically stored without deflate.

Fix: read the compression method at offset 8 of the local file header; for method 0 the block is the content itself, recompress it into COMPRESSED so `get( )` keeps working unchanged.

Found by running the bizhuka/xtt image-demo template (its embedded PNG is a STORED entry) through `load( )`.

Testcase: hand-crafted single-entry STORED archive.