### PR TITLE
ixml parser: strip leading byte order mark

### DIFF
--- a/src/ixml/cl_ixml.clas.locals_imp.abap
+++ b/src/ixml/cl_ixml.clas.locals_imp.abap
@@ -1263,6 +1263,7 @@ CLASS lcl_parser IMPLEMENTATION.
   METHOD if_ixml_parser~parse.
 
     DATA lv_xml       TYPE string.
+    DATA lv_bom       TYPE c LENGTH 1.
     DATA lv_offset    TYPE i.
     DATA lv_value     TYPE string.
     DATA lv_name      TYPE string.
@@ -1281,6 +1282,12 @@ CLASS lcl_parser IMPLEMENTATION.
 * get the private value from istream,
     stream = mi_istream.
     WRITE '@KERNEL lv_xml.set(stream.get().mv_xml);'.
+
+* strip the byte order mark, it is not part of the document
+    lv_bom = cl_abap_conv_in_ce=>uccpi( 65279 ).
+    IF lv_xml IS NOT INITIAL AND lv_xml(1) = lv_bom.
+      lv_xml = lv_xml+1.
+    ENDIF.
 
     REPLACE ALL OCCURRENCES OF |\n| IN lv_xml WITH ||.
 

--- a/src/ixml/cl_ixml.clas.testclasses.abap
+++ b/src/ixml/cl_ixml.clas.testclasses.abap
@@ -17,6 +17,7 @@ CLASS ltcl_xml DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
     METHODS parse_basic FOR TESTING RAISING cx_static_check.
     METHODS root_element_after_crlf FOR TESTING RAISING cx_static_check.
     METHODS first_child_after_crlf FOR TESTING RAISING cx_static_check.
+    METHODS parse_bom FOR TESTING RAISING cx_static_check.
     METHODS parse_empty FOR TESTING RAISING cx_static_check.
     METHODS parse_namespace FOR TESTING RAISING cx_static_check.
     METHODS parse_unescape FOR TESTING RAISING cx_static_check.
@@ -404,6 +405,7 @@ CLASS ltcl_xml IMPLEMENTATION.
     " return remains and becomes a #text node before the root element
     lv_xml = |<?xml version="1.0"?>\r\n<root><item>A</item></root>|.
 
+
     li_root = parse( lv_xml )->get_root_element( ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -423,6 +425,24 @@ CLASS ltcl_xml IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals(
       act = li_child->get_name( )
+      exp = `root` ).
+
+  ENDMETHOD.
+
+  METHOD parse_bom.
+
+    DATA lv_bom  TYPE c LENGTH 1.
+    DATA lv_xml  TYPE string.
+    DATA li_root TYPE REF TO if_ixml_element.
+
+    " U+FEFF byte order mark, found at the start of many real-world files
+    lv_bom = cl_abap_conv_in_ce=>uccpi( 65279 ).
+    CONCATENATE lv_bom `<?xml version="1.0"?><root><item>A</item></root>` INTO lv_xml.
+
+    li_root = parse( lv_xml )->get_root_element( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_root->get_name( )
       exp = `root` ).
 
   ENDMETHOD.


### PR DESCRIPTION
A BOM (U+FEFF) at the start of the input is not markup: it fell through to the text branch of the parser and became a #text node BEFORE the root element, so `get_root_element( )` returned the wrong node. Real-world files exported by Excel/Word frequently start with a BOM.

Fix: drop the first character when it is U+FEFF, right after the input string is obtained.

Testcase included (fails on current main: `get_root_element( )->get_name( )` returns `#text`).