### PR TITLE
ixml document: get_root_element/get_first_child skip leading #text

### DIFF
--- a/src/ixml/cl_ixml.clas.locals_imp.abap
+++ b/src/ixml/cl_ixml.clas.locals_imp.abap
@@ -885,7 +885,14 @@ CLASS lcl_document IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD if_ixml_document~get_first_child.
-    child = mi_node->if_ixml_node~get_first_child( ).
+* skip whitespace #text nodes before the root element, they are not
+* part of the document structure
+    DATA li_iterator TYPE REF TO if_ixml_node_iterator.
+    li_iterator = mi_node->if_ixml_node~get_children( )->create_iterator( ).
+    child = li_iterator->get_next( ).
+    WHILE child IS NOT INITIAL AND child->get_name( ) = `#text`.
+      child = li_iterator->get_next( ).
+    ENDWHILE.
   ENDMETHOD.
 
   METHOD if_ixml_document~create_attribute_ns.
@@ -1026,7 +1033,7 @@ CLASS lcl_document IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD if_ixml_document~get_root_element.
-    root ?= mi_node->if_ixml_element~get_first_child( ).
+    root ?= if_ixml_document~get_first_child( ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/ixml/cl_ixml.clas.testclasses.abap
+++ b/src/ixml/cl_ixml.clas.testclasses.abap
@@ -15,6 +15,8 @@ CLASS ltcl_xml DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
     METHODS render_nested FOR TESTING RAISING cx_static_check.
     METHODS render_document_namespace_pref FOR TESTING RAISING cx_static_check.
     METHODS parse_basic FOR TESTING RAISING cx_static_check.
+    METHODS root_element_after_crlf FOR TESTING RAISING cx_static_check.
+    METHODS first_child_after_crlf FOR TESTING RAISING cx_static_check.
     METHODS parse_empty FOR TESTING RAISING cx_static_check.
     METHODS parse_namespace FOR TESTING RAISING cx_static_check.
     METHODS parse_unescape FOR TESTING RAISING cx_static_check.
@@ -391,6 +393,38 @@ CLASS ltcl_xml IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = lv_subrc
       exp = 0 ).
+  ENDMETHOD.
+
+  METHOD root_element_after_crlf.
+
+    DATA lv_xml  TYPE string.
+    DATA li_root TYPE REF TO if_ixml_element.
+
+    " CRLF after the prolog: parse( ) removes newlines but the carriage
+    " return remains and becomes a #text node before the root element
+    lv_xml = |<?xml version="1.0"?>\r\n<root><item>A</item></root>|.
+
+    li_root = parse( lv_xml )->get_root_element( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_root->get_name( )
+      exp = `root` ).
+
+  ENDMETHOD.
+
+  METHOD first_child_after_crlf.
+
+    DATA lv_xml   TYPE string.
+    DATA li_child TYPE REF TO if_ixml_node.
+
+    lv_xml = |<?xml version="1.0"?>\r\n<root><item>A</item></root>|.
+
+    li_child = parse( lv_xml )->get_first_child( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_child->get_name( )
+      exp = `root` ).
+
   ENDMETHOD.
 
   METHOD parse_basic.


### PR DESCRIPTION
The parser removes newlines but keeps carriage returns, so any CRLF-formatted file (`<?xml ...?>\r\n<root>`) produces a #text node before the root element — and both `get_root_element( )` and the document's `get_first_child( )` returned it instead of the root.

Fix: the document's `get_first_child( )` skips #text children (in SAP iXML the prolog whitespace is not part of the document tree), `get_root_element( )` delegates to it.

Two testcases included; both fail on current main with `act = '#text'`.