### PR TITLE
ixml: set_attribute replaces an existing attribute instead of duplicating

### DIFF
--- a/src/ixml/cl_ixml.clas.locals_imp.abap
+++ b/src/ixml/cl_ixml.clas.locals_imp.abap
@@ -125,6 +125,19 @@ CLASS lcl_named_node_map IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD if_ixml_named_node_map~set_named_item_ns.
+* replace an existing node with the same name, otherwise add it,
+* appending unconditionally produces duplicate attributes
+    DATA lv_index TYPE i.
+    DATA li_node  LIKE LINE OF mt_list.
+
+    LOOP AT mt_list INTO li_node.
+      lv_index = sy-tabix.
+      IF li_node->get_name( ) = node->get_name( ).
+        MODIFY mt_list INDEX lv_index FROM node.
+        RETURN.
+      ENDIF.
+    ENDLOOP.
+
     APPEND node TO mt_list.
   ENDMETHOD.
 ENDCLASS.

--- a/src/ixml/cl_ixml.clas.testclasses.abap
+++ b/src/ixml/cl_ixml.clas.testclasses.abap
@@ -110,7 +110,7 @@ CLASS ltcl_xml IMPLEMENTATION.
 
     li_element = mi_document->create_simple_element( name   = `tag`
                                                      parent = mi_document ).
-    li_element->set_attribute( name  = `count` 
+    li_element->set_attribute( name  = `count`
                                value = `1` ).
     li_element->set_attribute( name  = `count` 
                                value = `2` ).

--- a/src/ixml/cl_ixml.clas.testclasses.abap
+++ b/src/ixml/cl_ixml.clas.testclasses.abap
@@ -112,7 +112,7 @@ CLASS ltcl_xml IMPLEMENTATION.
                                                      parent = mi_document ).
     li_element->set_attribute( name  = `count`
                                value = `1` ).
-    li_element->set_attribute( name  = `count` 
+    li_element->set_attribute( name  = `count`
                                value = `2` ).
 
     cl_abap_unit_assert=>assert_equals(

--- a/src/ixml/cl_ixml.clas.testclasses.abap
+++ b/src/ixml/cl_ixml.clas.testclasses.abap
@@ -36,6 +36,7 @@ CLASS ltcl_xml DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
     METHODS parse_tag_space FOR TESTING RAISING cx_static_check.
     METHODS create FOR TESTING RAISING cx_static_check.
     METHODS create_set_attributes FOR TESTING RAISING cx_static_check.
+    METHODS set_attribute_twice FOR TESTING RAISING cx_static_check.
     METHODS parse_and_render FOR TESTING RAISING cx_static_check.
     METHODS parse_close_tag FOR TESTING RAISING cx_static_check.
     METHODS parse_more FOR TESTING RAISING cx_static_check.
@@ -100,6 +101,28 @@ CLASS ltcl_xml IMPLEMENTATION.
   METHOD setup.
     mi_ixml = cl_ixml=>create( ).
     mi_document = mi_ixml->create_document( ).
+  ENDMETHOD.
+
+  METHOD set_attribute_twice.
+
+    DATA li_element TYPE REF TO if_ixml_element.
+    DATA lv_xml     TYPE string.
+
+    li_element = mi_document->create_simple_element( name   = `tag`
+                                                     parent = mi_document ).
+    li_element->set_attribute( name = `count` value = `1` ).
+    li_element->set_attribute( name = `count` value = `2` ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_element->get_attribute( `count` )
+      exp = `2` ).
+
+    lv_xml = render( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_xml
+      exp = |<?xml version="1.0" encoding="utf-16"?><tag count="2"/>| ).
+
   ENDMETHOD.
 
   METHOD create_set_attributes.

--- a/src/ixml/cl_ixml.clas.testclasses.abap
+++ b/src/ixml/cl_ixml.clas.testclasses.abap
@@ -110,8 +110,10 @@ CLASS ltcl_xml IMPLEMENTATION.
 
     li_element = mi_document->create_simple_element( name   = `tag`
                                                      parent = mi_document ).
-    li_element->set_attribute( name = `count` value = `1` ).
-    li_element->set_attribute( name = `count` value = `2` ).
+    li_element->set_attribute( name  = `count` 
+                               value = `1` ).
+    li_element->set_attribute( name  = `count` 
+                               value = `2` ).
 
     cl_abap_unit_assert=>assert_equals(
       act = li_element->get_attribute( `count` )


### PR DESCRIPTION
`set_named_item_ns( )` appended unconditionally, so calling `set_attribute( )` for a name that already exists produced a second attribute with the same name:

```xml
<mergeCells count="8" count="28">
```

Two consequences:
- `get_attribute( )` returns the stale first value
- the rendered document is not well-formed XML, so Excel and Word reject the file as corrupt

Found via bizhuka/xtt: when it expands columns it updates the mergeCells count, and every produced xlsx was unopenable — even though the zip itself was valid and read back fine programmatically.

Fix: replace the node when an attribute with the same name is already present, otherwise append.

Testcase included (fails on current main: `get_attribute` returns the first value).