### PR TITLE
ixml parser: keep whitespace inside values

### DIFF
--- a/src/ixml/cl_ixml.clas.locals_imp.abap
+++ b/src/ixml/cl_ixml.clas.locals_imp.abap
@@ -1275,8 +1275,10 @@ CLASS lcl_parser IMPLEMENTATION.
 
   METHOD if_ixml_parser~parse.
 
-    DATA lv_xml       TYPE string.
-    DATA lv_bom       TYPE c LENGTH 1.
+    DATA lv_xml        TYPE string.
+    DATA lv_rest       TYPE string.
+    DATA lv_whitespace TYPE string.
+    DATA lv_bom        TYPE c LENGTH 1.
     DATA lv_offset    TYPE i.
     DATA lv_value     TYPE string.
     DATA lv_name      TYPE string.
@@ -1295,6 +1297,8 @@ CLASS lcl_parser IMPLEMENTATION.
 * get the private value from istream,
     stream = mi_istream.
     WRITE '@KERNEL lv_xml.set(stream.get().mv_xml);'.
+
+    lv_whitespace = cl_abap_char_utilities=>get_simple_spaces_for_cur_cp( ).
 
 * strip the byte order mark, it is not part of the document
     lv_bom = cl_abap_conv_in_ce=>uccpi( 65279 ).
@@ -1358,7 +1362,15 @@ CLASS lcl_parser IMPLEMENTATION.
       ENDIF.
 
       lv_xml = lv_xml+lv_offset.
-      CONDENSE lv_xml.
+
+* skip whitespace between tags, but never touch text content: CONDENSE
+* also removed leading blanks of a value and collapsed blanks inside it,
+* so `<t xml:space="preserve">A  B</t>` lost characters
+      lv_rest = lv_xml.
+      SHIFT lv_rest LEFT DELETING LEADING lv_whitespace.
+      IF lv_rest IS INITIAL OR lv_rest(1) = '<'.
+        lv_xml = lv_rest.
+      ENDIF.
     ENDWHILE.
 
   ENDMETHOD.

--- a/src/ixml/cl_ixml.clas.testclasses.abap
+++ b/src/ixml/cl_ixml.clas.testclasses.abap
@@ -27,6 +27,7 @@ CLASS ltcl_xml DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
     METHODS parse_attributes3 FOR TESTING RAISING cx_static_check.
     METHODS parse_attributes4 FOR TESTING RAISING cx_static_check.
     METHODS parse_value_whitespace FOR TESTING RAISING cx_static_check.
+    METHODS parse_value_spaces_kept FOR TESTING RAISING cx_static_check.
     METHODS parse_special FOR TESTING RAISING cx_static_check.
     METHODS parse_hash FOR TESTING RAISING cx_static_check.
     METHODS parse_attr_dash FOR TESTING RAISING cx_static_check.
@@ -698,6 +699,22 @@ CLASS ltcl_xml IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = li_element->get_value( )
       exp = |&<>"'| ).
+
+  ENDMETHOD.
+
+  METHOD parse_value_spaces_kept.
+
+    DATA lv_xml  TYPE string.
+    DATA li_root TYPE REF TO if_ixml_element.
+
+    " spaces inside a value are data, also leading ones
+    lv_xml = |<t xml:space="preserve"> A  B</t>|.
+
+    li_root = parse( lv_xml )->get_root_element( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_root->get_value( )
+      exp = | A  B| ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
After each token the parser ran `CONDENSE` on the rest of the document. That also removed leading blanks of the next value and collapsed blanks inside it:

- `<t xml:space="preserve"> A  B</t>` is parsed as `A B`

Any document text with double spaces or indentation silently loses characters, which shows up in xlsx/docx content read through iXML.

Fix: skip leading whitespace only when a tag follows, so whitespace between elements is still ignored while text content stays untouched.

Testcase included (fails on current main with `act = 'A B'`). Full test suite passes.