### PR TITLE
Change condition from 'IS SUPPLIED' to 'IS NOT INITIAL'

### DIFF
--- a/src/unit/cl_abap_unit_assert.clas.abap
+++ b/src/unit/cl_abap_unit_assert.clas.abap
@@ -408,7 +408,7 @@ CLASS cl_abap_unit_assert IMPLEMENTATION.
       compare_tables(
         act = act
         exp = exp ).
-    ELSEIF tol IS SUPPLIED.
+    ELSEIF tol IS NOT INITIAL.
       diff = exp - act.
 *      WRITE '@KERNEL console.dir(tol);'.
 *      WRITE '@KERNEL console.dir(diff);'.

--- a/src/unit/cl_abap_unit_assert.clas.testclasses.abap
+++ b/src/unit/cl_abap_unit_assert.clas.testclasses.abap
@@ -37,10 +37,17 @@ CLASS ltcl_test DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
     METHODS non_compareable4 FOR TESTING RAISING cx_static_check.
     METHODS non_compareable5 FOR TESTING RAISING cx_static_check.
     METHODS non_compareable6 FOR TESTING RAISING cx_static_check.
-
+    METHODS zero_tol FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 CLASS ltcl_test IMPLEMENTATION.
+
+  METHOD zero_tol.
+    cl_abap_unit_assert=>assert_equals(
+      exp = 0
+      act = 0
+      tol = 0 ).
+  ENDMETHOD.
 
   METHOD char_n_pack.
     TYPES total TYPE p LENGTH 3 DECIMALS 2.


### PR DESCRIPTION
have a wrapper on top of cl_Abap_Unit_Assert

in standard class cl_Abap_Unit_Assert


analysis_Svc=>is_Equal( )

  method is_Equal.
    if ( tol is not initial and