### PR TITLE
DDIC: released data elements CHAR5, CHAR64, CHAR100, CHAR200

### DIFF
--- a/src/ddic/dtel/char100.dtel.xml
+++ b/src/ddic/dtel/char100.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>CHAR100</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Character field of length 100</DDTEXT>
+    <REPTEXT>Character field of length 100</REPTEXT>
+    <SCRTEXT_S>CHAR100</SCRTEXT_S>
+    <SCRTEXT_M>CHAR100</SCRTEXT_M>
+    <SCRTEXT_L>CHAR100</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000100</LENG>
+    <OUTPUTLEN>000100</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/char200.dtel.xml
+++ b/src/ddic/dtel/char200.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>CHAR200</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Character field of length 200</DDTEXT>
+    <REPTEXT>Character field of length 200</REPTEXT>
+    <SCRTEXT_S>CHAR200</SCRTEXT_S>
+    <SCRTEXT_M>CHAR200</SCRTEXT_M>
+    <SCRTEXT_L>CHAR200</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000200</LENG>
+    <OUTPUTLEN>000200</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/char5.dtel.xml
+++ b/src/ddic/dtel/char5.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>CHAR5</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Character field of length 5</DDTEXT>
+    <REPTEXT>Character field of length 5</REPTEXT>
+    <SCRTEXT_S>CHAR5</SCRTEXT_S>
+    <SCRTEXT_M>CHAR5</SCRTEXT_M>
+    <SCRTEXT_L>CHAR5</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000005</LENG>
+    <OUTPUTLEN>000005</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/char64.dtel.xml
+++ b/src/ddic/dtel/char64.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>CHAR64</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Character field of length 64</DDTEXT>
+    <REPTEXT>Character field of length 64</REPTEXT>
+    <SCRTEXT_S>CHAR64</SCRTEXT_S>
+    <SCRTEXT_M>CHAR64</SCRTEXT_M>
+    <SCRTEXT_L>CHAR64</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000064</LENG>
+    <OUTPUTLEN>000064</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Four released (C1) character data elements: \`CHAR5\`, \`CHAR64\`, \`CHAR100\`, \`CHAR200\`, all in \`abapedia/steampunk-2305-api\`.

Reduced from eleven after the rule "only released data elements in open-abap-core": \`UZEIT\` is in \`abapedia/s4-private-2022-doma-and-dtel\` and needs no copy, \`CHAR50\`, \`CHAR258\`, \`CHAR1024\`, \`NUMC7\`, \`INTEGER\`, \`SAP_BOOL\` are neither released nor in that dump and go to open-abap-deprecated.

Found by generating the SEGW classes of eight public repositories and compiling them against open-abap-odata (open-steamgate \`docs/segw-closure.md\`). Lengths as in the SAP DDIC, no domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU3xTpNL1QDbNkGzuZ4pqg