### PR TITLE
DDIC: VBELN, POSNR, PERNR_D, BU_PARTNER, XUBNAME, UNAM, CNAM, SYSUUID_X, DDPOSITION

### DIFF
--- a/src/ddic/dtel/bu_partner.dtel.xml
+++ b/src/ddic/dtel/bu_partner.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>BU_PARTNER</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Business Partner Number</DDTEXT>
+    <REPTEXT>Business Partner Number</REPTEXT>
+    <SCRTEXT_S>BU_PARTNER</SCRTEXT_S>
+    <SCRTEXT_M>BU_PARTNER</SCRTEXT_M>
+    <SCRTEXT_L>BU_PARTNER</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000010</LENG>
+    <OUTPUTLEN>000010</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/cnam.dtel.xml
+++ b/src/ddic/dtel/cnam.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>CNAM</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Author</DDTEXT>
+    <REPTEXT>Author</REPTEXT>
+    <SCRTEXT_S>CNAM</SCRTEXT_S>
+    <SCRTEXT_M>CNAM</SCRTEXT_M>
+    <SCRTEXT_L>CNAM</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000012</LENG>
+    <OUTPUTLEN>000012</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/ddposition.dtel.xml
+++ b/src/ddic/dtel/ddposition.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>DDPOSITION</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Position of the field in the table</DDTEXT>
+    <REPTEXT>Position of the field in the table</REPTEXT>
+    <SCRTEXT_S>DDPOSITION</SCRTEXT_S>
+    <SCRTEXT_M>DDPOSITION</SCRTEXT_M>
+    <SCRTEXT_L>DDPOSITION</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>NUMC</DATATYPE>
+    <LENG>000004</LENG>
+    <DECIMALS>000000</DECIMALS>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/pernr_d.dtel.xml
+++ b/src/ddic/dtel/pernr_d.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>PERNR_D</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Personnel Number</DDTEXT>
+    <REPTEXT>Personnel Number</REPTEXT>
+    <SCRTEXT_S>PERNR_D</SCRTEXT_S>
+    <SCRTEXT_M>PERNR_D</SCRTEXT_M>
+    <SCRTEXT_L>PERNR_D</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>NUMC</DATATYPE>
+    <LENG>000008</LENG>
+    <DECIMALS>000000</DECIMALS>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/posnr.dtel.xml
+++ b/src/ddic/dtel/posnr.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>POSNR</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Item number of the SD document</DDTEXT>
+    <REPTEXT>Item number of the SD document</REPTEXT>
+    <SCRTEXT_S>POSNR</SCRTEXT_S>
+    <SCRTEXT_M>POSNR</SCRTEXT_M>
+    <SCRTEXT_L>POSNR</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>NUMC</DATATYPE>
+    <LENG>000006</LENG>
+    <DECIMALS>000000</DECIMALS>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/sysuuid_x.dtel.xml
+++ b/src/ddic/dtel/sysuuid_x.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>SYSUUID_X</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>16 Byte UUID in 16 Bytes (Raw Format)</DDTEXT>
+    <REPTEXT>16 Byte UUID in 16 Bytes (Raw Format)</REPTEXT>
+    <SCRTEXT_S>SYSUUID_X</SCRTEXT_S>
+    <SCRTEXT_M>SYSUUID_X</SCRTEXT_M>
+    <SCRTEXT_L>SYSUUID_X</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>RAW</DATATYPE>
+    <LENG>000016</LENG>
+    <DECIMALS>000000</DECIMALS>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/unam.dtel.xml
+++ b/src/ddic/dtel/unam.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>UNAM</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Last Changed By</DDTEXT>
+    <REPTEXT>Last Changed By</REPTEXT>
+    <SCRTEXT_S>UNAM</SCRTEXT_S>
+    <SCRTEXT_M>UNAM</SCRTEXT_M>
+    <SCRTEXT_L>UNAM</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000012</LENG>
+    <OUTPUTLEN>000012</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/vbeln.dtel.xml
+++ b/src/ddic/dtel/vbeln.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>VBELN</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Sales and Distribution Document Number</DDTEXT>
+    <REPTEXT>Sales and Distribution Document Number</REPTEXT>
+    <SCRTEXT_S>VBELN</SCRTEXT_S>
+    <SCRTEXT_M>VBELN</SCRTEXT_M>
+    <SCRTEXT_L>VBELN</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000010</LENG>
+    <OUTPUTLEN>000010</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/xubname.dtel.xml
+++ b/src/ddic/dtel/xubname.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>XUBNAME</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>User Name in User Master Record</DDTEXT>
+    <REPTEXT>User Name in User Master Record</REPTEXT>
+    <SCRTEXT_S>XUBNAME</SCRTEXT_S>
+    <SCRTEXT_M>XUBNAME</SCRTEXT_M>
+    <SCRTEXT_L>XUBNAME</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000012</LENG>
+    <OUTPUTLEN>000012</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Nine key-like data elements: `VBELN`, `POSNR`, `PERNR_D`, `BU_PARTNER`, `XUBNAME`, `UNAM`, `CNAM`, `SYSUUID_X`, `DDPOSITION`.

Found by generating the SEGW classes of eight public repositories and compiling them against open-abap-odata (open-steamgate `docs/segw-closure.md`): these are the standard data elements their entity structures are typed with. Lengths and types as in the SAP DDIC, no domains, no conversion exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU3xTpNL1QDbNkGzuZ4pqg