### PR TITLE
DDIC: transport organizer data elements PGMID, TROBJTYPE, TRSTATUS, TR_AS4USER

### DIFF
--- a/src/ddic/dtel/pgmid.dtel.xml
+++ b/src/ddic/dtel/pgmid.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>PGMID</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Program ID in Requests and Tasks</DDTEXT>
+    <REPTEXT>Program ID in Requests and Tasks</REPTEXT>
+    <SCRTEXT_S>PGMID</SCRTEXT_S>
+    <SCRTEXT_M>PGMID</SCRTEXT_M>
+    <SCRTEXT_L>PGMID</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000004</LENG>
+    <OUTPUTLEN>000004</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/tr_as4user.dtel.xml
+++ b/src/ddic/dtel/tr_as4user.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>TR_AS4USER</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Owner of a Request or Task</DDTEXT>
+    <REPTEXT>Owner of a Request or Task</REPTEXT>
+    <SCRTEXT_S>TR_AS4USER</SCRTEXT_S>
+    <SCRTEXT_M>TR_AS4USER</SCRTEXT_M>
+    <SCRTEXT_L>TR_AS4USER</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000012</LENG>
+    <OUTPUTLEN>000012</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/trobjtype.dtel.xml
+++ b/src/ddic/dtel/trobjtype.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>TROBJTYPE</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Object Type</DDTEXT>
+    <REPTEXT>Object Type</REPTEXT>
+    <SCRTEXT_S>TROBJTYPE</SCRTEXT_S>
+    <SCRTEXT_M>TROBJTYPE</SCRTEXT_M>
+    <SCRTEXT_L>TROBJTYPE</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000004</LENG>
+    <OUTPUTLEN>000004</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ddic/dtel/trstatus.dtel.xml
+++ b/src/ddic/dtel/trstatus.dtel.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DTEL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD04V>
+    <ROLLNAME>TRSTATUS</ROLLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <HEADLEN>55</HEADLEN>
+    <SCRLEN1>10</SCRLEN1>
+    <SCRLEN2>20</SCRLEN2>
+    <SCRLEN3>40</SCRLEN3>
+    <DDTEXT>Status of request/task</DDTEXT>
+    <REPTEXT>Status of request/task</REPTEXT>
+    <SCRTEXT_S>TRSTATUS</SCRTEXT_S>
+    <SCRTEXT_M>TRSTATUS</SCRTEXT_M>
+    <SCRTEXT_L>TRSTATUS</SCRTEXT_L>
+    <DTELMASTER>E</DTELMASTER>
+    <DATATYPE>CHAR</DATATYPE>
+    <LENG>000001</LENG>
+    <OUTPUTLEN>000001</OUTPUTLEN>
+   </DD04V>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Four transport organizer data elements next to the existing `TRKORR` and `TRFUNCTION`: `PGMID`, `TROBJTYPE`, `TRSTATUS`, `TR_AS4USER`.

Found by generating the SEGW classes of eight public repositories and compiling them against open-abap-odata (open-steamgate `docs/segw-closure.md`): these are the standard data elements their entity structures are typed with. Lengths and types as in the SAP DDIC, no domains, no conversion exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU3xTpNL1QDbNkGzuZ4pqg