### PR TITLE
cl_abap_typedescr=>describe_by_name: resolve an absolute type name

### DIFF
--- a/src/rtti/cl_abap_typedescr.clas.abap
+++ b/src/rtti/cl_abap_typedescr.clas.abap
@@ -169,6 +169,24 @@ CLASS cl_abap_typedescr IMPLEMENTATION.
     DATA objectdescr TYPE REF TO cl_abap_objectdescr.
     DATA oo_type     TYPE string.
     DATA lv_any      TYPE string.
+    DATA lv_absolute TYPE string.
+    DATA lv_offset   TYPE i.
+
+* an ABSOLUTE type name - the spelling a serialized type descriptor carries -
+* is resolved by its relative part, as a system does: \TYPE=STRING is STRING.
+* FIND rather than a prefix strip, so that \TYPE-POOL=ABAP\TYPE=ABAP_BOOL
+* finds the segment that names the type; generated names (%) are left alone,
+* their relative part names nothing
+    lv_absolute = p_name.
+    IF lv_absolute CP '\TYPE*' AND lv_absolute NA '%'.
+      FIND FIRST OCCURRENCE OF '\TYPE=' IN lv_absolute MATCH OFFSET lv_offset.
+      IF sy-subrc = 0.
+        lv_offset = lv_offset + 6.
+        lv_absolute = lv_absolute+lv_offset.
+        type = describe_by_name( lv_absolute ).
+        RETURN.
+      ENDIF.
+    ENDIF.
 
 * note, p_name might be internal name, so check and skip these,
     IF p_name CA '-' AND p_name NP 'CLAS-*' AND p_name NP 'PROG-*'.

--- a/src/rtti/cl_abap_typedescr.clas.testclasses.abap
+++ b/src/rtti/cl_abap_typedescr.clas.testclasses.abap
@@ -35,6 +35,7 @@ CLASS ltcl_test DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
 
   PRIVATE SECTION.
     METHODS typekind_int FOR TESTING.
+    METHODS describe_by_name_absolute FOR TESTING.
     METHODS typekind_char FOR TESTING.
     METHODS typekind_structure1 FOR TESTING.
     METHODS typekind_structure2 FOR TESTING.
@@ -334,6 +335,22 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = type->type_kind
       exp = cl_abap_typedescr=>typekind_dref ).
+  ENDMETHOD.
+
+  METHOD describe_by_name_absolute.
+    DATA type TYPE REF TO cl_abap_typedescr.
+
+    type = cl_abap_typedescr=>describe_by_name( '\TYPE=STRING' ).
+    cl_abap_unit_assert=>assert_not_initial( type ).
+    cl_abap_unit_assert=>assert_equals(
+      act = type->type_kind
+      exp = cl_abap_typedescr=>typekind_string ).
+
+    type = cl_abap_typedescr=>describe_by_name( '\TYPE-POOL=ABAP\TYPE=ABAP_BOOL' ).
+    cl_abap_unit_assert=>assert_not_initial( type ).
+    cl_abap_unit_assert=>assert_equals(
+      act = type->type_kind
+      exp = cl_abap_typedescr=>typekind_char ).
   ENDMETHOD.
 
   METHOD typekind_int.


### PR DESCRIPTION
`describe_by_name` cannot resolve an absolute type name - the spelling a
serialized type descriptor carries:

```abap
DATA lo_type TYPE REF TO cl_abap_typedescr.

lo_type = cl_abap_typedescr=>describe_by_name( '\TYPE=STRING' ).
" SAP:  the STRING descriptor
" here: EXCEPTION type_not_found
```

The name is handed straight to `CREATE DATA TYPE (p_name)`, which does not
take it, so the method raises `type_not_found`. `\TYPE=I`, `\TYPE=STRING` and
`\TYPE-POOL=ABAP\TYPE=ABAP_BOOL` are the spellings that show up in practice.

### Why it matters

In abap2UI5: the framework carries the type of a runtime-built
table across the roundtrip in its draft, through exactly that S-RTTI restore.
That is the shape of every runtime-typed screen - a DDIC structure's
components plus a selection flag - and each of them died on restore in the
transpiled backend, which is why the test covering it
(`ltcl_test_app_root4->test_tab_ref_gen`) had to be skipped there for years.
abap2UI5 has been applying this change as a local patch on the pinned
open-abap-core checkout on every transpiled run since 2026-09-02, and that
test runs with it.

### The change

The fix resolves such a name by its relative part, as SAP does. Two details:

- `FIND FIRST OCCURRENCE OF '\TYPE='` rather than a prefix strip, so that
  `\TYPE-POOL=ABAP\TYPE=ABAP_BOOL` resolves to `ABAP_BOOL` - the type-pool
  segment spells `\TYPE-POOL=` and does not match, so the first match is the
  segment that names the type.
- `NA '%'` leaves generated and anonymous names (`\TYPE=%_T00001`) alone;
  their relative part names nothing, and re-entering with it would turn a
  clean `type_not_found` into a confusing one.

It recurses through the public method instead of duplicating the lookup, so
everything the relative path already handles stays handled.

### Test

`describe_by_name_absolute` covers both spellings. `npm test` is green; with
the `describe_by_name` change reverted the new test fails with
`type_not_found`, so it covers the gap rather than passing either way.